### PR TITLE
Replace source command with period

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,13 +2,10 @@
 [run]
 branch = True
 include =
-    latex2sympy.py
+    src/*
 omit = 
     sandbox/*
-    gen/*
-    asciimath_printer.py
     setup.py
-    __init__.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -33,9 +33,9 @@ echo ''
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then source .env/bin/activate && echo "venv activate (bin)"
+then . ./.env/bin/activate && echo "venv activate (bin)"
 elif test -f .env/Scripts/activate
-then source .env/Scripts/activate && echo "venv activated (Scripts)"
+then . .env/Scripts/activate && echo "venv activated (Scripts)"
 else exit 1
 fi
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -33,7 +33,7 @@ echo ''
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then . ./.env/bin/activate && echo "venv activate (bin)"
+then . .env/bin/activate && echo "venv activate (bin)"
 elif test -f .env/Scripts/activate
 then . .env/Scripts/activate && echo "venv activated (Scripts)"
 else exit 1

--- a/scripts/coverage-ci.sh
+++ b/scripts/coverage-ci.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pytest --doctest-modules --junitxml=junit/test-results.xml --cov-report=xml --cov-config=.coveragerc --cov=latex2sympy tests
+pytest --doctest-modules --junitxml=junit/test-results.xml --cov-report=xml --cov-config=.coveragerc --cov=src tests

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -9,9 +9,9 @@ cd $rel_path
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then source .env/bin/activate && echo "venv activate (bin)"
+then . .env/bin/activate && echo "venv activate (bin)"
 elif test -f .env/Scripts/activate
-then source .env/Scripts/activate && echo "venv activated (Scripts)"
+then . .env/Scripts/activate && echo "venv activated (Scripts)"
 else exit 1
 fi
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -17,7 +17,7 @@ fi
 
 # Run unit test coverage
 echo "starting coverage..."
-if pytest --doctest-modules --cov-report=html --cov-config=.coveragerc --cov=latex2sympy tests
+if pytest --doctest-modules --cov-report=html --cov-config=.coveragerc --cov=src tests
 then echo "coverage finished"
 else exit 1
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -12,9 +12,9 @@ echo "pre-commit hook started..."
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then source .env/bin/activate && echo "venv activated."
+then . .env/bin/activate && echo "venv activated."
 elif test -f .env/Scripts/activate
-then source .env/Scripts/activate && echo "venv activated."
+then . .env/Scripts/activate && echo "venv activated."
 else exit 1
 fi
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -12,9 +12,9 @@ echo "pre-push hook started..."
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then source .env/bin/activate && echo "venv activated."
+then . .env/bin/activate && echo "venv activated."
 elif test -f .env/Scripts/activate
-then source .env/Scripts/activate && echo "venv activated."
+then . .env/Scripts/activate && echo "venv activated."
 else exit 1
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,9 +16,9 @@ echo ''
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then source .env/bin/activate && echo "venv activate (bin)"
+then . ./.env/bin/activate && echo "venv activate (bin)"
 elif test -f .env/Scripts/activate
-then source .env/Scripts/activate && echo "venv activated (Scripts)"
+then . .env/Scripts/activate && echo "venv activated (Scripts)"
 else exit 1
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ echo ''
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then . ./.env/bin/activate && echo "venv activate (bin)"
+then . .env/bin/activate && echo "venv activate (bin)"
 elif test -f .env/Scripts/activate
 then . .env/Scripts/activate && echo "venv activated (Scripts)"
 else exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,9 +9,9 @@ cd $rel_path
 # Activate virtual environment
 echo "activating venv..."
 if test -f .env/bin/activate
-then source .env/bin/activate && echo "venv activate (bin)"
+then . .env/bin/activate && echo "venv activate (bin)"
 elif test -f .env/Scripts/activate
-then source .env/Scripts/activate && echo "venv activated (Scripts)"
+then . .env/Scripts/activate && echo "venv activated (Scripts)"
 else exit 1
 fi
 


### PR DESCRIPTION
The `source` command is an alias for the period `.` that was added by bash. This replaces the uses of `source` with a period for greater shell compatibility.